### PR TITLE
Use latest super pom

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.zepben.maven</groupId>
         <artifactId>evolve-super-pom</artifactId>
-        <version>0.23.0</version>
+        <version>0.26.0</version>
     </parent>
 
     <groupId>com.zepben.protobuf</groupId>


### PR DESCRIPTION
# Description

Latest super pom will ensure service descriptors are packaged appropriately. It doesn't really impact evolve-grpc itself as it's a client issue, but it could if someone utilises transitive deps of this library probably. We want to keep versioning and packaging of all gRPC stuff consistent and this change is already flowing downstream from the SDK.

# Checklist:

- [x] I have performed a self review of my own code.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so.
