### PR TITLE
EWB-2980: Fix incorrect fieldname

### DIFF
--- a/proto/zepben/proto.lock
+++ b/proto/zepben/proto.lock
@@ -5886,7 +5886,7 @@
               },
               {
                 "id": 2,
-                "name": "transitTime",
+                "name": "inTransitTime",
                 "type": "double"
               }
             ]

--- a/proto/zepben/protobuf/cim/iec61970/base/wires/Breaker.proto
+++ b/proto/zepben/protobuf/cim/iec61970/base/wires/Breaker.proto
@@ -30,6 +30,6 @@ message Breaker {
     /**
      * The transition time from open to close in seconds.
      */
-    double transitTime = 2;
+    double inTransitTime = 2;
 
 }


### PR DESCRIPTION
# Description

`Switch.transitTime` should be `Switch.inTransitTime`. This fixes that.

# Associated tasks:

Tasks blocking this one:
- None

Tasks this is blocking:
- https://github.com/zepben/evolve-sdk-jvm/pull/131

# Checklist:

- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
