### PR TITLE
Make inverseTimeFlag nullable

### DIFF
--- a/proto/zepben/proto.lock
+++ b/proto/zepben/proto.lock
@@ -5559,7 +5559,12 @@
               },
               {
                 "id": 3,
-                "name": "inverseTimeFlag",
+                "name": "null",
+                "type": "google.protobuf.NullValue"
+              },
+              {
+                "id": 4,
+                "name": "set",
                 "type": "bool"
               },
               {
@@ -5573,6 +5578,9 @@
         "imports": [
           {
             "path": "zepben/protobuf/cim/iec61970/base/protection/ProtectionEquipment.proto"
+          },
+          {
+            "path": "google/protobuf/struct.proto"
           }
         ],
         "package": {

--- a/proto/zepben/protobuf/cim/iec61970/base/protection/CurrentRelay.proto
+++ b/proto/zepben/protobuf/cim/iec61970/base/protection/CurrentRelay.proto
@@ -13,6 +13,8 @@ option csharp_namespace = "Zepben.Protobuf.CIM.IEC61970.Base.Protection";
 package zepben.protobuf.cim.iec61970.base.protection;
 
 import "zepben/protobuf/cim/iec61970/base/protection/ProtectionEquipment.proto";
+import "google/protobuf/struct.proto";
+
 
 /**
  * A device that checks current flow values in any direction or designated direction.
@@ -32,7 +34,10 @@ message CurrentRelay {
   /**
    * Set true if the current relay has inverse time characteristic.
    */
-  bool inverseTimeFlag = 3;
+  oneof inverseTimeFlag {
+      google.protobuf.NullValue null = 3;
+      bool set = 4;
+  }
 
   /**
    * Inverse time delay number 1 for current limit number 1 in seconds.


### PR DESCRIPTION
# Description

Make inverseTimeFlag nullable.

# Associated tasks:

https://github.com/zepben/evolve-sdk-jvm/pull/131#pullrequestreview-1216794567

# Checklist:

These are always required, if you do not do them, reviewers will be angry:
- [x] I have performed a self review of my own code.
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~ no tests...

These you can remove from the list if they are not applicable for this PR.
- [x] I have updated any documentation required for these changes.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so.
