### PR TITLE
PROJ-3370: Added `Syf.installedTxCapacity`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,9 @@
 * Added new RPCs:
   * `getDiagramObjects`: Get the DiagramObjects for a given mRID.
   * `getCustomersForContainer`: Get the customers for a given EquipmentContainer. 
-* Added OpenDSS `Model`, `LoadShape` and `EnergyMeter` report messages for hosting capacity.
+* Added the following messages for hosting capacity:
+  * `Syf` and `Job` messages for hosting capacity control.
+  * `Model`, `LoadShape` and `EnergyMeter` report messages for streaming results from OpenDSS.
 * Added `Job` message for hosting capacity, which describes a hosting capacity run for a single feeder.
 * Added CIM enums:
   * `PowerDirectionKind`

--- a/proto/zepben/protobuf/hc/Syf.proto
+++ b/proto/zepben/protobuf/hc/Syf.proto
@@ -32,4 +32,9 @@ message Syf {
      */
     string feeder = 3;
 
+    /**
+     * A map of elements to the VA ratings of transformers in the model for this syf below the element (they may have been changed from the base model).
+     */
+    map<string, int64> installedTxCapacity = 4;
+
 }


### PR DESCRIPTION
# Description

Added the `installedTxCapacity` field to the hosting capacity `Syf` message to allow the model builder to store the capacity of transformers in the modified models it produces.

# Checklist:

These are always required, if you do not do them, reviewers will be angry:
- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.

These you can remove from the list if they are not applicable for this PR.
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so.
