### PR TITLE
Add more metadata to SYF message

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,10 @@
 
 * `ratedS` has been deprecated from PowerTransformerEnd. Use `ratings` instead.
 * Added configs to `Job` message for CIM to OpenDSS translation and OpenDSS solve parameters.
+* Added the following metadata fields to the hosting capacity `Job` message:
+  * `normVMinPu`
+  * `normVMaxPu`
+  * `resultsDetailLevel`
 
 ### Enhancements
 

--- a/proto/zepben/proto.lock
+++ b/proto/zepben/proto.lock
@@ -9680,28 +9680,6 @@
     {
       "protopath": "protobuf:/:hc:/:Job.proto",
       "def": {
-        "enums": [
-          {
-            "name": "ResultsDetailLevel",
-            "enum_fields": [
-              {
-                "name": "STANDARD"
-              },
-              {
-                "name": "BASIC",
-                "integer": 1
-              },
-              {
-                "name": "EXTENDED",
-                "integer": 2
-              },
-              {
-                "name": "RAW",
-                "integer": 3
-              }
-            ]
-          }
-        ],
         "messages": [
           {
             "name": "Job",
@@ -9752,6 +9730,9 @@
           },
           {
             "path": "zepben/protobuf/hc/SolveConfig.proto"
+          },
+          {
+            "path": "zepben/protobuf/hc/ResultsDetailLevel.proto"
           }
         ],
         "package": {
@@ -9865,6 +9846,50 @@
                 "id": 2,
                 "name": "namePattern",
                 "type": "string"
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "zepben.protobuf.hc"
+        },
+        "options": [
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_package",
+            "value": "com.zepben.protobuf.hc"
+          },
+          {
+            "name": "csharp_namespace",
+            "value": "Zepben.Protobuf.HC"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "protobuf:/:hc:/:ResultsDetailLevel.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "ResultsDetailLevel",
+            "enum_fields": [
+              {
+                "name": "STANDARD"
+              },
+              {
+                "name": "BASIC",
+                "integer": 1
+              },
+              {
+                "name": "EXTENDED",
+                "integer": 2
+              },
+              {
+                "name": "RAW",
+                "integer": 3
               }
             ]
           }
@@ -10006,6 +10031,21 @@
               },
               {
                 "id": 5,
+                "name": "normVMinPu",
+                "type": "double"
+              },
+              {
+                "id": 6,
+                "name": "normVMaxPu",
+                "type": "double"
+              },
+              {
+                "id": 7,
+                "name": "resultsDetailLevel",
+                "type": "ResultsDetailLevel"
+              },
+              {
+                "id": 8,
                 "name": "qualityAssuranceProcessing",
                 "type": "bool"
               }
@@ -10020,6 +10060,11 @@
                 }
               }
             ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "zepben/protobuf/hc/ResultsDetailLevel.proto"
           }
         ],
         "package": {

--- a/proto/zepben/protobuf/hc/Job.proto
+++ b/proto/zepben/protobuf/hc/Job.proto
@@ -14,6 +14,7 @@ package zepben.protobuf.hc;
 
 import "zepben/protobuf/hc/ModelConfig.proto";
 import "zepben/protobuf/hc/SolveConfig.proto";
+import "zepben/protobuf/hc/ResultsDetailLevel.proto";
 
 /**
  * Describes a work package for the HC model processor.
@@ -47,13 +48,6 @@ message Job {
 
   /**
    * Specifies the level of detail in the results.
-   *  - STANDARD: The default level. Contains information on overloaded parts of the network, peak import and export,
-   *              and overall network utilisation.
-   *  - BASIC: A level below STANDARD. Contains only minimal information on overloaded network parts, net energy flow,
-   *           peak active/apparent power, and gross generated/delivered energy.
-   *  - EXTENDED: Contains all information from BASIC and STANDARD combined. Enables overload report processing.
-   *  - RAW: The most verbose detail level. Does the same as EXTENDED but also enables the results processor to
-   *         populate separate database tables that contain the raw results.
    */
   ResultsDetailLevel resultsDetailLevel = 6;
 
@@ -62,11 +56,4 @@ message Job {
    */
   bool qualityAssuranceProcessing = 7;
 
-}
-
-enum ResultsDetailLevel {
-  STANDARD = 0;
-  BASIC = 1;
-  EXTENDED = 2;
-  RAW = 3;
 }

--- a/proto/zepben/protobuf/hc/ResultsDetailLevel.proto
+++ b/proto/zepben/protobuf/hc/ResultsDetailLevel.proto
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+syntax = "proto3";
+option java_multiple_files = true;
+option java_package = "com.zepben.protobuf.hc";
+option csharp_namespace = "Zepben.Protobuf.HC";
+package zepben.protobuf.hc;
+
+/**
+  * Specifies a level of detail in the results.
+  *  - STANDARD: The default level. Contains information on overloaded parts of the network, peak import and export,
+  *              and overall network utilisation.
+  *  - BASIC: A level below STANDARD. Contains only minimal information on overloaded network parts, net energy flow,
+  *           peak active/apparent power, and gross generated/delivered energy.
+  *  - EXTENDED: Contains all information from BASIC and STANDARD combined. Enables overload report processing.
+  *  - RAW: The most verbose detail level. Does the same as EXTENDED but also enables the results processor to
+  *         populate separate database tables that contain the raw results.
+  */
+enum ResultsDetailLevel {
+  STANDARD = 0;
+  BASIC = 1;
+  EXTENDED = 2;
+  RAW = 3;
+}

--- a/proto/zepben/protobuf/hc/Syf.proto
+++ b/proto/zepben/protobuf/hc/Syf.proto
@@ -12,6 +12,8 @@ option java_package = "com.zepben.protobuf.hc";
 option csharp_namespace = "Zepben.Protobuf.HC";
 package zepben.protobuf.hc;
 
+import "zepben/protobuf/hc/ResultsDetailLevel.proto";
+
 /**
  * A Scenario/Year/Feeder tuple. This is the base unit of our hosting capacity orchestration.
  * This also contains metadata about the model that the results processor needs.
@@ -39,8 +41,23 @@ message Syf {
     map<string, int64> installedTxCapacity = 4;
 
     /**
+     * Controls min voltage for use in network performance metrics.
+     */
+    double normVMinPu = 5;
+
+    /**
+     * Controls max voltage for use in network performance metrics.
+     */
+    double normVMaxPu = 6;
+
+    /**
+     * Specifies the level of detail in the results.
+     */
+    ResultsDetailLevel resultsDetailLevel = 7;
+
+    /**
      * Whether to run QA checks with the model.
      */
-    bool qualityAssuranceProcessing = 5;
+    bool qualityAssuranceProcessing = 8;
 
 }


### PR DESCRIPTION
# Description

Adds the following fields to the `Syf` message:
- `double normVMinPu`: lower bound for normal voltage PU range
- `double normVMaxPu`: upper bound for normal voltage PU range
- `ResultsDetailLevel resultsDetailLevel`: Level of detail for results

# Associated tasks:

Tasks blocking this one:
- None

Tasks this is blocking:
- https://app.clickup.com/t/6929263/PROJ-3746 (PR TBA)

# Checklist:

These are always required, if you do not do them, reviewers will be angry:
- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary. (No tests necessary for protobuf change)

These you can remove from the list if they are not applicable for this PR.
- [x] I have updated the changelog.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so.
