### PR TITLE
PROJ-3731: Log message

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
   * `normVMinPu`
   * `normVMaxPu`
   * `resultsDetailLevel`
+* Added `LogMessage` to the hosting capacity module, which is used to carry logs between HC processes.
 
 ### Enhancements
 

--- a/proto/zepben/protobuf/hc/LogMessage.proto
+++ b/proto/zepben/protobuf/hc/LogMessage.proto
@@ -17,42 +17,47 @@ import "google/protobuf/struct.proto";
 
 message LogMessage {
   /**
+   * The ID of the work package.
+   */
+  string workPackageId = 1;
+
+  /**
    * The name of the scenario.
    */
-  string scenario = 1;
+  string scenario = 2;
 
   /**
    * The year in the scenario.
    */
-  int32 year = 2;
+  int32 year = 3;
 
   /**
    * The name of the feeder.
    */
-  string feeder = 3;
+  string feeder = 4;
 
   /**
    * Time step if this model was a single time step model. Null must be set if not.
    */
   oneof timeStep {
-    google.protobuf.NullValue timeStepNull = 4;
-    google.protobuf.Timestamp timeStepSet = 5;
+    google.protobuf.NullValue timeStepNull = 5;
+    google.protobuf.Timestamp timeStepSet = 6;
   }
 
   /**
    * The time at which this error occurred.
    */
-  google.protobuf.Timestamp timestamp = 6;
+  google.protobuf.Timestamp timestamp = 7;
 
   /**
    * The log level of this failure message.
    */
-  LogLevel severity = 7;
+  LogLevel severity = 8;
 
   /**
    * The message to report.
    */
-  string message = 8;
+  string message = 9;
 
 }
 

--- a/proto/zepben/protobuf/hc/LogMessage.proto
+++ b/proto/zepben/protobuf/hc/LogMessage.proto
@@ -29,40 +29,43 @@ message LogMessage {
   /**
    * The year in the scenario.
    */
-  int32 year = 3;
+  oneof year {
+    google.protobuf.NullValue yearNull = 3;
+    int32 yearSet = 4;
+  }
 
   /**
    * The name of the feeder.
    */
-  string feeder = 4;
+  string feeder = 5;
 
   /**
    * Time step if this model was a single time step model. Null must be set if not.
    */
   oneof timeStep {
-    google.protobuf.NullValue timeStepNull = 5;
-    google.protobuf.Timestamp timeStepSet = 6;
+    google.protobuf.NullValue timeStepNull = 6;
+    google.protobuf.Timestamp timeStepSet = 7;
   }
 
   /**
    * The time at which this error occurred.
    */
-  google.protobuf.Timestamp timestamp = 7;
+  google.protobuf.Timestamp timestamp = 8;
 
   /**
    * The log level of this failure message.
    */
-  LogLevel severity = 8;
+  LogLevel severity = 9;
 
   /**
    * The message to report.
    */
-  string message = 9;
+  string message = 10;
 
   /**
    * The type of process the log originates from.
    */
-  LogSource source = 10;
+  LogSource source = 11;
 
 }
 

--- a/proto/zepben/protobuf/hc/LogMessage.proto
+++ b/proto/zepben/protobuf/hc/LogMessage.proto
@@ -59,6 +59,11 @@ message LogMessage {
    */
   string message = 9;
 
+  /**
+   * The type of process the log originates from.
+   */
+  LogSource source = 10;
+
 }
 
 enum LogLevel {
@@ -66,4 +71,10 @@ enum LogLevel {
   WARN = 1;
   ERROR = 2;
   DEBUG = 3;
+}
+
+enum LogSource {
+  MODEL_GENERATOR = 0;
+  MODEL_EXECUTOR = 1;
+  RESULT_PROCESSOR = 2;
 }

--- a/proto/zepben/protobuf/hc/LogMessage.proto
+++ b/proto/zepben/protobuf/hc/LogMessage.proto
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+syntax = "proto3";
+option java_multiple_files = true;
+option java_package = "com.zepben.protobuf.hc";
+option csharp_namespace = "Zepben.Protobuf.HC";
+package zepben.protobuf.hc;
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/struct.proto";
+
+message LogMessage {
+  /**
+   * The name of the scenario.
+   */
+  string scenario = 1;
+
+  /**
+   * The year in the scenario.
+   */
+  int32 year = 2;
+
+  /**
+   * The name of the feeder.
+   */
+  string feeder = 3;
+
+  /**
+   * Time step if this model was a single time step model. Null must be set if not.
+   */
+  oneof timeStep {
+    google.protobuf.NullValue timeStepNull = 4;
+    google.protobuf.Timestamp timeStepSet = 5;
+  }
+
+  /**
+   * The time at which this error occurred.
+   */
+  google.protobuf.Timestamp timestamp = 6;
+
+  /**
+   * The log level of this failure message.
+   */
+  LogLevel severity = 7;
+
+  /**
+   * The message to report.
+   */
+  string message = 8;
+
+}
+
+enum LogLevel {
+  INFO = 0;
+  WARN = 1;
+  ERROR = 2;
+  DEBUG = 3;
+}


### PR DESCRIPTION
# Description

Adds message to be used for sending logs between HC processes.

# Associated tasks:

Tasks blocking this one:
- None

Tasks this is blocking:
- Send logs from executor to results processor
- Store warnings and above from executor in logs table

# Checklist:

These are always required, if you do not do them, reviewers will be angry:
- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary. (Protobuf change does not need tests)

These you can remove from the list if they are not applicable for this PR.
- [x] I have updated the changelog.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so. (Not breaking)
