### PR TITLE
Add config properties for processors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 
 ### New Features
 * Support passing configuration for results in Syf and Job messages.
+* Support passing arbitrary one-off configuration for hosting capacity processors in Job and Syf messages.
 * Added load data date time information to ModelConfig and Syf messages.
 * Added load data timezone information to ModelConfig and Syf messages.
 * Added calibration flag to ModelConfig message.

--- a/proto/zepben/protobuf/hc/Job.proto
+++ b/proto/zepben/protobuf/hc/Job.proto
@@ -56,7 +56,6 @@ message Job {
    */
   bool qualityAssuranceProcessing = 7;
 
-
   /**
    * Compressed, base64'd JSON configuration to be passed to the model generator.
    */

--- a/proto/zepben/protobuf/hc/Job.proto
+++ b/proto/zepben/protobuf/hc/Job.proto
@@ -55,4 +55,21 @@ message Job {
    * Whether to enable QA checks for the OpenDSS model.
    */
   bool qualityAssuranceProcessing = 7;
+
+
+  /**
+   * Compressed, base64'd JSON configuration to be passed to the model generator.
+   */
+  string generatorConfig = 8;
+
+  /**
+   * Compressed, base64'd JSON configuration to be passed to the executor.
+   */
+  string executorConfig = 9;
+
+  /**
+   * Compressed, base64'd JSON configuration to be passed to the results processor.
+   */
+  string resultsProcessorConfig = 10;
+
 }

--- a/proto/zepben/protobuf/hc/Syf.proto
+++ b/proto/zepben/protobuf/hc/Syf.proto
@@ -84,4 +84,14 @@ message Syf {
      */
     string timezone = 13;
 
+    /**
+     * Compressed, base64'd JSON configuration to be passed to the executor.
+     */
+    string executorConfig = 14;
+
+    /**
+     * Compressed, base64'd JSON configuration to be passed to the results processor.
+     */
+    string resultsProcessorConfig = 15;
+
 }


### PR DESCRIPTION
# Description

Adds properties responsible for storing arbitrary JSON config for each of the hosting capacity processors.
This allows us to update the configuration for individual processors without having to update the protos. These config properties will be populated by the hosting capacity service when a Job message is received, and flow through to each processor.

# Checklist

If any of these are not applicable, strikethrough the line `~~like this~~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~ not necessary for proto updates
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

None