### PR TITLE
Added MeasurementZoneInfo to the Syf proto message.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@
 * None.
 
 ### Enhancements
-* None.
+* Added MeasurementZoneInfo to the Syf proto message.
 
 ### Fixes
 * None.

--- a/proto/zepben/protobuf/hc/Syf.proto
+++ b/proto/zepben/protobuf/hc/Syf.proto
@@ -12,6 +12,7 @@ option java_package = "com.zepben.protobuf.hc";
 option csharp_namespace = "Zepben.Protobuf.HC";
 package zepben.protobuf.hc;
 
+import "zepben/protobuf/hc/measurement/MeasurementZoneInfo.proto";
 import "zepben/protobuf/hc/ModelConfig.proto";
 import "zepben/protobuf/hc/ResultsConfig.proto";
 
@@ -93,5 +94,10 @@ message Syf {
      * Compressed, base64'd JSON configuration to be passed to the results processor.
      */
     string resultsProcessorConfig = 15;
+
+    /*
+     * Map of EnergyMeter IDs to their measurement zone info
+     */
+    map<string, measurement.MeasurementZoneInfo> mzInfo = 16;
 
 }

--- a/proto/zepben/protobuf/hc/measurement/MeasurementZoneInfo.proto
+++ b/proto/zepben/protobuf/hc/measurement/MeasurementZoneInfo.proto
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+syntax = "proto3";
+option java_multiple_files = true;
+option java_package = "com.zepben.protobuf.hc.measurement";
+option csharp_namespace = "Zepben.Protobuf.HC.Measurement";
+package zepben.protobuf.hc.measurement;
+
+enum MeasurementZoneType {
+    UNKNOWN = 0;
+    TRANSFORMER = 1;
+    BREAKER = 2;
+    DISCONNECTOR = 3;
+    FUSE = 4;
+    JUMPER = 5;
+    LOAD_BREAK_SWITCH = 6;
+    RECLOSER = 7;
+    ENERGY_CONSUMER = 8;
+    FEEDER_HEAD = 9;
+    CALIBRATION = 10;
+}
+
+message MeasurementZoneInfo {
+
+    /*
+     * The ConductingEquipment this measurement zone starts at.
+     */
+    string conductingEquipmentMRID = 1;
+
+    /*
+     * Sequence number of the terminal this measurement zone starts at.
+     */
+    uint32 terminalSequenceNumber = 2;
+
+    /*
+     * The voltage base to use for this measurement zone (in volts).
+     */
+    uint32 voltageBase = 3;
+
+    /*
+     * The type of this measurement zone (if known).
+     */
+    MeasurementZoneType type = 4;
+}


### PR DESCRIPTION
# Description

Added MeasurementZoneInfo to the Syf proto message. This was done to support splitting the information encoded in the measurement_zone_name column in the results database.

# Associated tasks

EWB-4077

# Checklist

### Code
- [X] I have performed a self review of my own code (including checking issues raised when creating the PR).
~~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~~
~~- [ ] I have commented my code in any hard-to-understand or hacky areas.~~
- [X] I have handled all new warnings generated by the compiler or IDE.
- [X] I have rebased onto the target branch (usually main).
      
### Documentation
- [X] I have updated the changelog.
~~- [ ] I have updated any documentation required for these changes.~~

# Breaking Changes
- [X] I have considered if this is a breaking change and will communicate it with other team members if so.
