### PR TITLE
EWB-4124: Update super pom to 0.34.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Zepben Protobuf and GRPC definitions
 ## [0.27.0] - UNRELEASED
 ### Breaking Changes
-* None.
+* Update to evolve-super-pom 0.34.1.
 
 ### New Features
 * None.

--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,17 @@
 # Zepben Protobuf and GRPC definitions
 ## [0.27.0] - UNRELEASED
 ### Breaking Changes
-* Update to evolve-super-pom 0.34.1.
+* None.
 
 ### New Features
 * None.
 
 ### Enhancements
 * Added MeasurementZoneInfo to the Syf proto message.
+* Bumped protobuf and gRPC versions:
+  * JVM (Maven): `com.google.protobuf:*:3.24.2`, `io.grpc:*:1.59.1`
+  * Python (setup.py): `protobuf==4.24.2`, `grpcio==1.59.3`, `grpcio-tools==1.59.3`
+  * C# (NuGet): `Google.Protobuf` version `3.24.2`, `Grpc.*` version `2.46.6`
 
 ### Fixes
 * None.

--- a/cs/evolve-grpc.csproj
+++ b/cs/evolve-grpc.csproj
@@ -27,9 +27,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.21.1"/>
-    <PackageReference Include="Grpc.Core" Version="2.46.3"/>
-    <PackageReference Include="Grpc.Tools" Version="2.46.3">
+    <PackageReference Include="Google.Protobuf" Version="3.24.2"/>
+    <PackageReference Include="Grpc.Core" Version="2.46.6"/>
+    <PackageReference Include="Grpc.Tools" Version="2.46.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.zepben.maven</groupId>
         <artifactId>evolve-super-pom</artifactId>
-        <version>0.33.0</version>
+        <version>0.34.1</version>
     </parent>
 
     <groupId>com.zepben.protobuf</groupId>

--- a/python/setup.py
+++ b/python/setup.py
@@ -18,11 +18,11 @@ setup(
     packages=find_namespace_packages(where="src"),
     python_requires='>=3.7',
     setup_requires=[
-        "grpcio-tools==1.59.1",
+        "grpcio-tools==1.59.3",
         "pep517"
     ],
     install_requires=[
         "protobuf==4.24.2",
-        "grpcio==1.59.1",
+        "grpcio==1.59.3",
     ],
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -18,11 +18,11 @@ setup(
     packages=find_namespace_packages(where="src"),
     python_requires='>=3.7',
     setup_requires=[
-        "grpcio-tools==1.57.0",
+        "grpcio-tools==1.59.1",
         "pep517"
     ],
     install_requires=[
         "protobuf==4.24.2",
-        "grpcio==1.57.0",
+        "grpcio==1.59.1",
     ],
 )


### PR DESCRIPTION
# Description

Use super pom version 0.34.1, fixing transient vulnerabilities from `grpc-netty-shaded:1.57.2`.

# Associated tasks

Tasks blocking this one:
- [x] https://github.com/zepben/evolve-super-pom/pull/36

Tasks this is blocking:
- https://github.com/zepben/hosting-capacity-utils/pull/12

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] ~I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~ (Tests did not break with version updates)
- [ ] ~I have commented my code in any hard-to-understand or hacky areas.~
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [x] I have updated the changelog.
- [ ] ~I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

No breaking changes.