### PR TITLE
Added reactive power values to LoadShape.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
   * Removed symmetric relation `ProtectionEquipment` &harr; `ProtectedSwitch`.
 * Renamed `CurrentRelayInfo` to `RelayInfo`.
 * Reworked values for enumerable type `ProtectionKind`.
+* `LoadShape`: added reactive power values to LoadShape.
 
 ### New Features
 * Added new messages and fields to support advanced modelling of protection relays:

--- a/proto/zepben/proto.lock
+++ b/proto/zepben/proto.lock
@@ -11964,12 +11964,18 @@
               },
               {
                 "id": 3,
-                "name": "values",
+                "name": "pValues",
                 "type": "float",
                 "is_repeated": true
               },
               {
                 "id": 4,
+                "name": "qValues",
+                "type": "float",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
                 "name": "normalise",
                 "type": "bool"
               }

--- a/proto/zepben/protobuf/hc/opendss/LoadShape.proto
+++ b/proto/zepben/protobuf/hc/opendss/LoadShape.proto
@@ -28,13 +28,18 @@ message LoadShape {
     double hrInterval = 2;
 
     /**
-     * The loadshapes values.
+     * The loadshapes P (real power) values.
      */
-    repeated float values = 3;
+    repeated float pValues = 3;
+
+    /**
+     * The loadshapes Q (reactive power) values.
+     */
+    repeated float qValues = 4;
 
     /**
      * Indication if the load shape needs to be normalised.
      */
-    bool normalise = 4;
+    bool normalise = 5;
 
 }


### PR DESCRIPTION
# Description

Added reactive power values to LoadShape.

# Associated tasks


# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [X] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
- [X] I have handled all new warnings generated by the compiler or IDE.
- [X] I have rebased onto the target branch (usually main).
      
### Documentation
- [X] I have updated the changelog.
- [X] I have updated any documentation required for these changes.

# Breaking Changes
- [X] I have considered if this is a breaking change and will communicate it with other team members if so.

It is a breaking change because the name for the values field changed to 'pValues', both the opendss-model-processor and the opendss-executor will need to be updated to handle this change.