### PR TITLE
Fix uploading the correct python artefact

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -131,7 +131,8 @@ jobs:
           twine upload --verbose --non-interactive --config-file ~/.pypirc dist/*
 
           # Output artifact-path to ENV
-          artifact="zepben.protobuf-${VERSION}-py3-none-any.whl"
+          version=$(grep version= setup.py | cut -d= -f2 | tr -d '",')
+          artifact="zepben.protobuf-${version}-py3-none-any.whl"
           echo "artifact-path=$(echo python/dist/$artifact)" >> ${GITHUB_ENV}
           # and 'artifact' to OUTPUT
           echo "artifact=$(echo $artifact)" >> ${GITHUB_OUTPUT} 


### PR DESCRIPTION
# Description

After the python package is built and deployed to pypi, we upload it to Github for interim step; we later download it again to package into the Github release.

This fix is for the interim uploading of the package to the Github.  

# Checklist

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
~- [ ] I have updated the changelog.~
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.