### PR TITLE
[DEV-8814] Fix the wrong version and changelog contents passing

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic
     outputs:
-      changelog: ${{ steps.check.outputs.changelog }}
-      version: ${{ steps.changelog.outputs.version }}
+      changelog: ${{ steps.changelog.outputs.changelog }}
+      version: ${{ steps.check.outputs.version }}
     env:
       NEXUS_MAVEN_REPO: ${{ secrets.NEXUS_MAVEN_REPO }}
       NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}


### PR DESCRIPTION
# Description

With previous changes to the `release-checks` workflow, we incorrectly passed the `version` and `changelog` parameters to the following workflows. This causes the "merge and tag" step to fail.

This change fixes it. This is purely a CI change, so it should be merged with `skip ci`