### PR TITLE
[DEV-9739] Java only update to Vertx v5, and matching `graphql-java` version.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Zepben Protobuf and GRPC definitions
 ## [1.8.0] - UNRELEASED
 ### Breaking Changes
-* None.
+* Java build updated to use Vert.x v5 transitive dependency.
 
 ### New Features
 * None.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.zepben.maven</groupId>
         <artifactId>evolve-super-pom</artifactId>
-        <version>0.49.0</version>
+        <version>0.51.0</version>
     </parent>
 
     <groupId>com.zepben</groupId>


### PR DESCRIPTION
# Description

Java only update to Vertx v5, and matching `graphql-java` version.

# Associated tasks

- https://github.com/zepben/ewb-super-pom/pull/76
- https://github.com/zepben/ewb-sdk-jvm/pull/281

# Test Steps

Explain in detail how your reviewer can test the changes proposed in this PR. If it cannot be tested, leave an explanation on why.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

### Security
When developing applications, use following guidelines for information security considerations:
* Access to applications should be protected with security keys/tokens or usernames and passwords;
* All sessions are encrypted if possible;
* All application input is sanitised before being acted on (ie SQL statements, etc);
* Log messages, and especially client-facing ones, must be handled securely and must not leak credentials information (internal URLs, passwords, tokens).

- [x] I have considered if this change impacts information security and made sure those impacts are handled.

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Transitive breaking changes for Vert.x v5.